### PR TITLE
Update OutboxCleanupService to apply correct batching

### DIFF
--- a/src/Whispr.EntityFrameworkCore/Cleaning/OutboxCleanupService.cs
+++ b/src/Whispr.EntityFrameworkCore/Cleaning/OutboxCleanupService.cs
@@ -48,8 +48,8 @@ internal sealed class OutboxCleanupService<TDbContext>(
                 .Where(x => x.ProcessedAtUtc < expiredUtc)
                 .Take(_batchSize)
                 .ExecuteDeleteAsync(cancellationToken);
-                
-            logger.LogInformation("Deleted {RowsDeleted} outbox messages older than {RetentionPeriod}", rowsDeleted, _retentionPeriod);
+            
+            if(rowsDeleted != 0) logger.LogInformation("Deleted {RowsDeleted} outbox messages older than {RetentionPeriod}", rowsDeleted, _retentionPeriod);
 
             if (rowsDeleted < _batchSize)
                 break;


### PR DESCRIPTION
- It definitely possible EF would optimize this automatically, but it seems more appropriate to put the take statement behind the orderby/where clauses in order to work as intended
- Moved the log statement so it will always log the deletions (not only when there is more to delete)