### PR TITLE
Make sure the inmemory transport is decoupled from the message handler

### DIFF
--- a/src/Whispr.AzureServiceBus/packages.lock.json
+++ b/src/Whispr.AzureServiceBus/packages.lock.json
@@ -68,6 +68,14 @@
         "resolved": "8.0.2",
         "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
       },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
         "resolved": "8.0.2",
@@ -176,6 +184,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[8.0.2, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[8.0.2, )",
           "Microsoft.Extensions.Options": "[8.0.2, )"
         }
       }
@@ -246,6 +255,14 @@
         "type": "Transitive",
         "resolved": "9.0.3",
         "contentHash": "TfaHPSe39NyL2wxkisRxXK7xvHGZYBZ+dy3r+mqGvnxKgAPdHkMu3QMQZI4pquP6W5FIQBqs8FJpWV8ffCgDqQ=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.3",
+        "contentHash": "H/MBMLt9A/69Ux4OrV7oCKt3DcMT04o5SCqDolulzQA66TLFEpYYb4qedMs/uwrLtyHXGuDGWKZse/oa8W9AZw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.3"
+        }
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -355,6 +372,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.3, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[9.0.3, )",
           "Microsoft.Extensions.Options": "[9.0.3, )"
         }
       }

--- a/src/Whispr.EntityFrameworkCore/packages.lock.json
+++ b/src/Whispr.EntityFrameworkCore/packages.lock.json
@@ -142,6 +142,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[8.0.2, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[8.0.2, )",
           "Microsoft.Extensions.Options": "[8.0.2, )"
         }
       }
@@ -289,6 +290,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.3, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[9.0.3, )",
           "Microsoft.Extensions.Options": "[9.0.3, )"
         }
       }

--- a/src/Whispr/GlobalUsings.cs
+++ b/src/Whispr/GlobalUsings.cs
@@ -1,6 +1,7 @@
 ﻿global using System.Text.Json;
 
 global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Logging;
 
 global using Whispr.Builder;
 global using Whispr.Bus;

--- a/src/Whispr/Whispr.csproj
+++ b/src/Whispr/Whispr.csproj
@@ -18,16 +18,19 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2"/>
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3"/>
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.3"/>
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Whispr.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
 </Project>

--- a/src/Whispr/packages.lock.json
+++ b/src/Whispr/packages.lock.json
@@ -8,6 +8,15 @@
         "resolved": "8.0.2",
         "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
       },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[8.0.2, )",
+        "resolved": "8.0.2",
+        "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
         "requested": "[8.0.2, )",
@@ -30,6 +39,15 @@
         "requested": "[9.0.3, )",
         "resolved": "9.0.3",
         "contentHash": "TfaHPSe39NyL2wxkisRxXK7xvHGZYBZ+dy3r+mqGvnxKgAPdHkMu3QMQZI4pquP6W5FIQBqs8FJpWV8ffCgDqQ=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[9.0.3, )",
+        "resolved": "9.0.3",
+        "contentHash": "H/MBMLt9A/69Ux4OrV7oCKt3DcMT04o5SCqDolulzQA66TLFEpYYb4qedMs/uwrLtyHXGuDGWKZse/oa8W9AZw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.3"
+        }
       },
       "Microsoft.Extensions.Options": {
         "type": "Direct",

--- a/tests/Whispr.Tests/Bus/MessageBusInitializerTests.cs
+++ b/tests/Whispr.Tests/Bus/MessageBusInitializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Whispr.Bus;
 using Whispr.Conventions;
 using Whispr.Tests.TestInfrastructure;
@@ -60,7 +61,8 @@ public sealed class MessageBusInitializerTests
                 CreateTopicNamingConvention(),
                 transportMock.Object,
                 serviceProvider,
-                new NoOpDiagnosticsEventListener());
+                new NoOpDiagnosticsEventListener(),
+                Mock.Of<ILogger<MessageBusInitializer>>());
 
             return new TestHarness { Initializer = initializer, Transport = transportMock };
         }


### PR DESCRIPTION
I considered using channels for this - but maybe this is just sufficient for now? 

For reference, it would look somewhat like this:

```
using System.Collections.Concurrent;
using System.Threading.Channels;

namespace Whispr.Transport;

internal sealed class InMemoryTransport(ILogger<InMemoryTransport> logger) : ITransport, IAsyncDisposable
{
    private readonly ConcurrentDictionary<string, Channel<SerializedEnvelope>> _queues = new ConcurrentDictionary<string, Channel<SerializedEnvelope>>();
    private readonly ConcurrentDictionary<string, List<string>> _subscriptions = new ConcurrentDictionary<string, List<string>>();
    private readonly CancellationTokenSource  _globalCts = new CancellationTokenSource();

    public ValueTask StartListener(
        string queueName,
        string[] topicNames,
        Func<SerializedEnvelope, CancellationToken, ValueTask> messageCallback,
        CancellationToken cancellationToken = default)
    {
        var queueChannel = _queues.GetOrAdd(queueName, _ => Channel.CreateUnbounded<SerializedEnvelope>());
        
        foreach (var topicName in topicNames)
        {
            _subscriptions.AddOrUpdate(
                topicName,
                _ => [queueName],
                (_, queues) =>
                {
                    if (!queues.Contains(queueName))
                    {
                        queues.Add(queueName);
                    }
                    return queues;
                });
        }
        
        var combinedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _globalCts.Token);
        _ = ProcessMessagesAsync(queueName, queueChannel.Reader, messageCallback, combinedCts.Token);
        
        return ValueTask.CompletedTask;
    }

    private async Task ProcessMessagesAsync(
        string queueName,
        ChannelReader<SerializedEnvelope> reader,
        Func<SerializedEnvelope, CancellationToken, ValueTask> messageCallback,
        CancellationToken cancellationToken)
    {
        try
        {
            while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
            {
                while (reader.TryRead(out var envelope))
                {
                    try
                    {
                        await messageCallback(envelope, cancellationToken).ConfigureAwait(false);
                    }
                    catch (Exception ex)
                    {
                        logger.LogError(ex, "Error processing message in queue \'{QueueName}\'", queueName);
                    }
                }
            }
        }
        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
        {
            // Normal cancellation, no need to do anything
        }
        catch (Exception ex)
        {
            logger.LogError(ex, "Error in queue processor \'{QueueName}\'", queueName);
        }
    }

    public async ValueTask Send(string topicName, SerializedEnvelope envelope, CancellationToken cancellationToken = default)
    {
        if (!_subscriptions.TryGetValue(topicName, out var subscribedQueues) || subscribedQueues.Count == 0)
        {
            return;
        }

        foreach (var queueName in subscribedQueues)
        {
            if (_queues.TryGetValue(queueName, out var channel))
            {
                await channel.Writer.WriteAsync(envelope, cancellationToken);
            }
        }
    }
    
    public async ValueTask DisposeAsync()
    {
        await _globalCts.CancelAsync();
        _globalCts.Dispose();
    }
}
```